### PR TITLE
Update optimizations.md

### DIFF
--- a/docs/build-workflows/optimizations.md
+++ b/docs/build-workflows/optimizations.md
@@ -8,5 +8,5 @@ opt-level = 'z'     # Optimize for size.
 lto = true          # Enable Link Time Optimization
 codegen-units = 1   # Reduce number of codegen units to increase optimizations.
 panic = 'abort'     # Abort on panic
-strip = true        # Strip symbols from binary*
+strip = 'debuginfo' # Strip symbols from binary*
 ```


### PR DESCRIPTION
Using `strip = true` works fine for everything on Mac but on Linux the stripped binary can't be used to generate. `strip = 'debuginfo'` gets most of the way there but can still be used for generating, and can be stripped the rest of the way with the Unix tool `strip` if desired.

If this is _only_ intended for use when creating the binary sent out with the packaged result, and can't be used for generating using `--library`, it might be worth calling out.