### PR TITLE
Showcase of failing test on external types

### DIFF
--- a/6-multiple-libraries/calendar-kotlin/lib/src/test/kotlin/org/examples/calendar/CalendarTest.kt
+++ b/6-multiple-libraries/calendar-kotlin/lib/src/test/kotlin/org/examples/calendar/CalendarTest.kt
@@ -6,7 +6,16 @@ import org.examples.clock.ClockType
 
 class CalendarTest {
     @Test
+    fun testClockType() {
+        val clockType: ClockType = ClockType.ANALOG
+    }
+
+    // This test will fail at runtime with error:
+    // java.lang.UnsatisfiedLinkError: Unable to load library 'clock_ffi':
+    // To make the test pass, you must build the clock_ffi library and include the dylib in the classpath.
+    @Test
     fun testCalendar() {
-        val clock_type: ClockType = ClockType.ANALOG
+        val clockType: ClockType = ClockType.ANALOG
+        val calendar = Calendar(42, clockType)
     }
 }


### PR DESCRIPTION
The test
```kotlin
@Test
fun testCalendar() {
    val clockType: ClockType = ClockType.ANALOG
    val calendar = Calendar(42, clockType)
}
```

Will fail at runtime with error
```sh
java.lang.UnsatisfiedLinkError: Unable to load library 'clock_ffi':
```

To make the test pass, you must build the clock_ffi library and include the dylib in the classpath. Am I missing something maybe? Or misconfigurating something? 